### PR TITLE
fix: Correct invalid character in SandboxTest.ps1

### DIFF
--- a/Tools/SandboxTest.ps1
+++ b/Tools/SandboxTest.ps1
@@ -55,7 +55,7 @@ $sandboxTestWsbContent = @"
     </MappedFolder>
   </MappedFolders>
   <LogonCommand>
-  <Command>PowerShell Start-Process PowerShell -WorkingDirectory '$tempFolderInSandbox' -ArgumentList '–ExecutionPolicy Bypass -NoExit -File $bootstrapPs1FileName'</Command>
+  <Command>PowerShell Start-Process PowerShell -WorkingDirectory '$tempFolderInSandbox' -ArgumentList '-ExecutionPolicy Bypass -NoExit -File $bootstrapPs1FileName'</Command>
   </LogonCommand>
 </Configuration>
 "@


### PR DESCRIPTION
The dash character in -ExecutionPolicy was a special character which broke the command.